### PR TITLE
Make GitHub recognize the Forth files.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+*.blk linguist-language=Forth
+*.scr linguist-language=Forth
+/camelforth/*.txt linguist-language=Forth
+/camelforth/camgloss.txt linguist-language=Text
+/camelforth/save_load.txt linguist-language=Text
+/camelforth/word_formats.txt linguist-language=Text


### PR DESCRIPTION
Helllo,

This makes GitHub recognize the `.blk`, `.scr`, and some `.txt` files as Forth.
